### PR TITLE
Issues 2 and 3

### DIFF
--- a/plotxvg
+++ b/plotxvg
@@ -138,7 +138,10 @@ class DataSet:
                 for d in range(len(ori_dataset)):
                     ds = ori_dataset
                     rmsd, r2 = self.calc_rmsd_r2(ds[d].x, ds[d].y)
-                    self.legend[d] = f"{self.legend[d]}, RMSD = {rmsd:.4f}, R2 = {r2:.4f}"
+                    print_r2 = f"{r2:.2f}"
+                    if print_r2 == "1.00":
+                        print_r2 = f"{r2:.4f}"
+                    self.legend[d] = f"{self.legend[d]}, RMSD = {rmsd:.2f}, R\u00b2 = {print_r2}"
 
     def set_extent(self, myax, args):
         if len(self.dataset) < 1:


### PR DESCRIPTION
Commit 1 fixes #2 so that even if fewer titles than number of files are given, None will be set for those files (no loss of legends)
Commit 2 fixes #3 namely to print a superscript 2 in R2 and to print fewer digits. What is added, however, is if R2 is for example 1.9997 is would be rounded to 1.00, which might be misleading, so more digits are added in those cases.
